### PR TITLE
Enable persistent host_keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,37 @@
-FROM alpine:3.4
+FROM    alpine:3.8
 
-MAINTAINER Carlos Bernárdez "carlos@z4studios.com"
+LABEL   maintainer='Carlos Bernárdez <carlos@z4studios.com>'
 
-# "--no-cache" is new in Alpine 3.3 and it avoid using
-# "--update + rm -rf /var/cache/apk/*" (to remove cache)
-RUN apk add --no-cache \
-# openssh=7.2_p2-r1 \
-  openssh \
-# git=2.8.3-r0
-  git
-
-# Key generation on the server
-RUN ssh-keygen -A
-
-# SSH autorun
-# RUN rc-update add sshd
+RUN     apk add --no-cache openssh git
 
 WORKDIR /git-server/
 
+RUN     mkdir -p keys-host/etc/ssh && \
+        ssh-keygen -A -f keys-host  && \
+        mv keys-host/etc/ssh/* keys-host && \
+        rm -rf keys-host/etc
+
 # -D flag avoids password generation
 # -s flag changes user's shell
-RUN mkdir /git-server/keys \
-  && adduser -D -s /usr/bin/git-shell git \
-  && echo git:12345 | chpasswd \
-  && mkdir /home/git/.ssh
+RUN     mkdir keys && \
+        adduser -D -s /usr/bin/git-shell git && \
+        echo git:12345 | chpasswd && \
+        mkdir /home/git/.ssh
 
 # This is a login shell for SSH accounts to provide restricted Git access.
 # It permits execution only of server-side Git commands implementing the
 # pull/push functionality, plus custom commands present in a subdirectory
 # named git-shell-commands in the user’s home directory.
 # More info: https://git-scm.com/docs/git-shell
-COPY git-shell-commands /home/git/git-shell-commands
+COPY    git-shell-commands /home/git/git-shell-commands
 
 # sshd_config file is edited for enable access key and disable access password
-COPY sshd_config /etc/ssh/sshd_config
-COPY start.sh start.sh
+COPY    sshd_config /etc/ssh/sshd_config
 
-EXPOSE 22
+COPY    start.sh start.sh
 
-CMD ["sh", "start.sh"]
+EXPOSE  22
+
+VOLUME  ["/git/server/keys", "/git-server/keys-host", "/git-server/repos"]
+
+CMD     ["sh", "start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN     mkdir keys && \
 # More info: https://git-scm.com/docs/git-shell
 COPY    git-shell-commands /home/git/git-shell-commands
 
+RUN     echo '' > /etc/motd
+
 # sshd_config file is edited for enable access key and disable access password
 COPY    sshd_config /etc/ssh/sshd_config
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ How to list all repositories:
 * **Volumes**:
  * */git-server/keys*: Volume to store the users public keys
  * */git-server/repos*: Volume to store the repositories
+ * */git-server/keys-host*: Volume to store the SSHd host keys
 
 ### SSH Keys
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ How clone a repository:
 
 	$ git clone ssh://git@<ip-docker-server>:2222/git-server/repos/myrepo.git
 
+How to list all repositories:
+
+	$ ssh git@<ip-docker-server>:2222
+
 ### Arguments
 
 * **Expose ports**: 22

--- a/git-shell-commands/no-interactive-login
+++ b/git-shell-commands/no-interactive-login
@@ -2,4 +2,16 @@
 printf '%s\n' "Welcome to git-server-docker!"
 printf '%s\n' "You've successfully authenticated, but I do not"
 printf '%s\n' "provide interactive shell access."
+
+printf '\n'
+printf '%s\n' "The following repositories are available:"
+for REPO in /git-server/repos/*
+do
+  printf '%s\n' " - $(basename ${REPO%.git})"
+done
+
+printf '\n'
+printf '%s\n' "To clone, use the following URL:"
+printf '%s\n' "ssh://git@<SERVER>:<PORT>/git-server/repos/<REPO_NAME>.git"
+
 exit 128

--- a/sshd_config
+++ b/sshd_config
@@ -20,11 +20,11 @@
 
 # HostKey for protocol version 1
 #HostKey /etc/ssh/ssh_host_key
-# HostKeys for protocol version 2
-#HostKey /etc/ssh/ssh_host_rsa_key
-#HostKey /etc/ssh/ssh_host_dsa_key
-#HostKey /etc/ssh/ssh_host_ecdsa_key
-#HostKey /etc/ssh/ssh_host_ed25519_key
+#HostKeys for protocol version 2
+HostKey /git-server/keys-host/ssh_host_rsa_key
+HostKey /git-server/keys-host/ssh_host_dsa_key
+HostKey /git-server/keys-host/ssh_host_ecdsa_key
+HostKey /git-server/keys-host/ssh_host_ed25519_key
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h


### PR DESCRIPTION
Original pull request: jkarlosb/git-server-docker#15

* Added volume for host keys and modified SSHd configuration for it
* Added possibility to list repositories using a simple ssh login

